### PR TITLE
BUG: parentheses error

### DIFF
--- a/interface-bonedensity-holologic-apex/src/main/java/org/obiba/onyx/jade/instrument/holologic/APEXScanDataExtractor.java
+++ b/interface-bonedensity-holologic-apex/src/main/java/org/obiba/onyx/jade/instrument/holologic/APEXScanDataExtractor.java
@@ -467,7 +467,7 @@ public abstract class APEXScanDataExtractor {
            ethnicity.equals("O") ||
            ethnicity.equals("P") ||
            ethnicity.equals("I") ||
-           (type.equals("R") && ethnicity.equals("H")) || ethnicity.equals("B")) {
+           (type.equals("R") && (ethnicity.equals("H") || ethnicity.equals("B")))) {
         ethnicity = " AND ETHNIC IS NULL";
       } else {
         ethnicity = " AND ETHNIC = '" + ethnicity + "'";


### PR DESCRIPTION
- missing parentheses lead to incorrect condition on
  ethnicity for forearm Z score computations: Hologic has
  no reference curve data for black or hispanic forearm